### PR TITLE
Add copyright to test.lua, using lua-udev.c text

### DIFF
--- a/test.lua
+++ b/test.lua
@@ -1,3 +1,23 @@
+-- Copyright (c) 2012 dodo <dodo.the.last@gmail.com>
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+-- THE SOFTWARE.
+
 print"require"
 local udev = require 'udev'
 local socket = require 'socket'


### PR DESCRIPTION
Hello,

Debian is rather careful with licensing so while it may be strongly implied what the license on test.lua it would make my life easier if it were explicit. I've taken the liberty of copying the license text and copyright from lua-udev.c having taken a guess that this is the license you would want. If not then I'd be happy to make another patch with the license statement you've chosen.

Thanks,
Ian.
